### PR TITLE
Add support for roles claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.8.0
+
+* Add support for `roles` claim.
+
 ## v0.7.0
 
-* Add support `email_verified` and `phone_number_verified` claims.
+* Add support for `email_verified` and `phone_number_verified` claims.
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     ```elixir
     def deps do
       [
-        {:gamora, "~> 0.7"}
+        {:gamora, "~> 0.8"}
       ]
     end
     ```

--- a/lib/gamora/plugs/adapters/idp_adapter.ex
+++ b/lib/gamora/plugs/adapters/idp_adapter.ex
@@ -44,6 +44,7 @@ defmodule Gamora.Plugs.AuthenticatedUser.IdpAdapter do
     Enum.reduce(claims, %{}, fn {claim, value}, attrs ->
       case claim do
         "sub" -> Map.put(attrs, :id, value)
+        "roles" -> Map.put(attrs, :roles, value)
         "email" -> Map.put(attrs, :email, value)
         "given_name" -> Map.put(attrs, :first_name, value)
         "family_name" -> Map.put(attrs, :last_name, value)

--- a/lib/gamora/user.ex
+++ b/lib/gamora/user.ex
@@ -1,6 +1,7 @@
 defmodule Gamora.User do
   @type t :: %__MODULE__{
           id: binary | nil,
+          roles: map | nil,
           email: binary | nil,
           last_name: binary | nil,
           first_name: binary | nil,
@@ -10,6 +11,7 @@ defmodule Gamora.User do
         }
 
   defstruct id: nil,
+            roles: nil,
             email: nil,
             last_name: nil,
             first_name: nil,

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gamora.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/amco/gamora-ex"
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [


### PR DESCRIPTION
## Addresses issue: [#IDP-225](https://amcoit.atlassian.net/browse/IDP-225)

If the `roles` scope was provided to the IDP, the claims will include a roles key. This PR adds the support to have that attribute in the Gamora.User module.