### PR TITLE
Add documentation to Gamora.Cache module

### DIFF
--- a/lib/gamora/cache.ex
+++ b/lib/gamora/cache.ex
@@ -1,5 +1,7 @@
 defmodule Gamora.Cache do
-  @moduledoc false
+  @moduledoc """
+  Default Gamora cache implementation.
+  """
 
   use Nebulex.Cache,
     otp_app: :gamora,


### PR DESCRIPTION
Add documentation to Gamora.Cache module to prevent following error when publishing the package:
```
warning: documentation references module "Gamora.Cache" but it is hidden
  README.md
```