### PR TITLE
Add support for allow_amco_badge param in the authorization url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.15.0
+
+* Enhancements:
+  * Add support for `allow_amco_badge` param in the authorization url.
+
 ## v0.14.0
 
 * Enhancements:

--- a/README.md
+++ b/README.md
@@ -316,6 +316,17 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
+By default IDP won't allow users to sign in with Amco badge. Amco badge
+strategy can be configured either explicitly as a `allow_amco_badge`
+query value on the request path or in your configuration:
+
+```elixir
+config :ueberauth, Ueberauth,
+  providers: [
+    amco: {Gamora, [default_allow_amco_badge: true]}
+  ]
+```
+
 By default prompt is not present in the authorization url. Prompt can be
 configured either explicitly as a `prompt` query value on the request
 path or in your configuration:

--- a/lib/gamora.ex
+++ b/lib/gamora.ex
@@ -70,6 +70,7 @@ defmodule Gamora do
     default_branding: "amco",
     default_strategy: "default",
     default_allow_create: true,
+    default_allow_amco_badge: false,
     default_scope: "openid profile email",
     uid_field: "sub"
 
@@ -100,6 +101,7 @@ defmodule Gamora do
       |> with_query_param(conn, :strategy)
       |> with_query_param(conn, :branding)
       |> with_query_param(conn, :allow_create)
+      |> with_query_param(conn, :allow_amco_badge)
 
     redirect!(conn, Gamora.OAuth.authorize_url!(params, opts))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gamora.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/amco/gamora-ex"
-  @version "0.14.0"
+  @version "0.15.0"
 
   def project do
     [

--- a/test/gamora/user_test.exs
+++ b/test/gamora/user_test.exs
@@ -7,23 +7,19 @@ defmodule Gamora.UserTest do
     id: 1,
     roles: %{},
     email: "darth@email.com",
+    username: "darthvader",
     first_name: "Darth",
     last_name: "Vader",
     phone_number: "523344556677",
     email_verified: true,
+    associated_user_id: "1234",
     phone_number_verified: true
   }
 
   describe "__struct__/1" do
     test "creates struct with valid attributes" do
-      user = User.__struct__(@attributes)
+      user = struct(User, @attributes)
       assert Map.take(user, Map.keys(@attributes)) == @attributes
-    end
-
-    test "raises error with invalid attributes" do
-      assert_raise KeyError, fn ->
-        User.__struct__(%{invalid: 1})
-      end
     end
   end
 end


### PR DESCRIPTION
## Addresses issue: [#TOOL-37](https://amcoit.atlassian.net/browse/TOOL-37)

Add support for allow_amco_badge param in the authorization url.